### PR TITLE
fix: workaround for bug in segment

### DIFF
--- a/src/segment.js
+++ b/src/segment.js
@@ -6,9 +6,9 @@ export default (function () {
   }
 
   return {
-    onRouteUpdate({ location }) {
+    onRouteUpdate() {
       if (!window.analytics) return;
-      window.analytics.page(); 
+      setTimeout(() => window.analytics.page(), 0);
     },
   };
 })();


### PR DESCRIPTION
This is a small fix so that the segment library uses the `location.pathname` of the latest page.

When a `setImmediate`-like function is not used, the segment library provides
the url path of the previous page, instead of the latest page.


Extra:
- I've removed the unused variable.