### PR TITLE
changed preconnect to support custom cdn host

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ module.exports = function (context, fromOptions) {
 
   const contents = snippet.min(segment);
 
+  const cdnHost = segment.useHostForBundles === true && segment.host ? segment.host : "cdn.segment.io";
+
   return {
     name: 'docusaurus-plugin-segment',
 
@@ -38,7 +40,7 @@ module.exports = function (context, fromOptions) {
             tagName: 'link',
             attributes: {
               rel: 'preconnect',
-              href: 'https://cdn.segment.io',
+              href: `https://${cdnHost}`,
             },
           },
           {


### PR DESCRIPTION
Add support for custom CDN hosts. [This pull request](https://github.com/segmentio/snippet/pull/76) on @segment/snippet adds a new config option `useHostForBundles` that tells segment to use the custom `host` for the bundle CDN. If this is set the preconnect url should be the custom `host` not segment's default.